### PR TITLE
Feature/per request url

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,9 @@ def deps do
 end
 ```
 
-Configure the endpoint you wish to use
+# Config
 
-```elixir
-config :pinxs,
-  pin_url: "https://api.pinpayments.com" # or "https://test-api.pin.net.au/1" in dev/test environment
-```
-
-You will also need to use your API key for authenticating each type of request.
+API key and the Pin URL are sent as a config object with each request.  `PINXS.config` helpers are provided for convenience.
 
 ## Overview
 

--- a/lib/http/client_base.ex
+++ b/lib/http/client_base.ex
@@ -2,8 +2,8 @@ defmodule PINXS.HTTP.ClientBase do
   @moduledoc false
   use HTTPoison.Base
 
-  def pin_url(url, %PINXS{url: base_url}) do
-    base_url <> url
+  def pin_url(path, %PINXS{url: base_url}) do
+    base_url <> path
   end
 
   def authenticated_delete(url, config) do

--- a/lib/http/client_base.ex
+++ b/lib/http/client_base.ex
@@ -2,30 +2,28 @@ defmodule PINXS.HTTP.ClientBase do
   @moduledoc false
   use HTTPoison.Base
 
-  @pin_url Application.get_env(:pinxs, :pin_url, "https://test-api.pin.net.au/1")
+  def pin_url(url, %PINXS{url: base_url}) do
+    base_url <> url
+  end
 
   def authenticated_delete(url, config) do
-    delete(url, transform_config(config), []) |> normalize()
+    delete(pin_url(url, config), transform_config(config), []) |> normalize()
   end
 
   def authenticated_get(url, config) do
-    get(url, transform_config(config), []) |> normalize()
+    get(pin_url(url, config), transform_config(config), []) |> normalize()
   end
 
   def authenticated_post(url, params, config) do
-    post(url, params, transform_config(config)) |> normalize()
+    post(pin_url(url, config), params, transform_config(config)) |> normalize()
   end
 
   def authenticated_put(url, params, config) do
-    put(url, params, transform_config(config)) |> normalize()
+    put(pin_url(url, config), params, transform_config(config)) |> normalize()
   end
 
   def authenticated_search(url, body, config) do
-    request(:get, url, body, transform_config(config)) |> normalize()
-  end
-
-  def process_url(endpoint) do
-    @pin_url <> endpoint
+    request(:get, pin_url(url, config), body, transform_config(config)) |> normalize()
   end
 
   def process_request_headers(headers) when is_list(headers), do: headers

--- a/lib/pinxs.ex
+++ b/lib/pinxs.ex
@@ -1,13 +1,40 @@
 defmodule PINXS do
-  @moduledoc false
-  @enforce_keys [:api_key]
-  defstruct [:api_key]
+  @moduledoc """
+  Convenience functions for building config structs
+  """
+  @enforce_keys [:api_key, :url]
+  defstruct [:api_key, :url]
 
   @type t :: %__MODULE__{
-    api_key: String.t()
-  }
+          api_key: String.t(),
+          url: String.t()
+        }
 
+  @doc """
+  Default usage is to just provide the api key
+
+      iex> PINXS.config("ABC123")
+      %PINXS{api_key: "ABC123", url: "https://api.pin.net.au/1"}
+
+  If you want to use test mode
+
+      iex> PINXS.config("ABC123")
+      %PINXS{api_key: "ABC123", url: "https://api.pin.net.au/1"}
+
+  Or you can have an arbitrary URL
+
+      iex> PINXS.config("ABC123", "https://my-fake-pin")
+      %PINXS{api_key: "ABC123", url: "https://my-fake-pin"}
+  """
   def config(api_key) do
-    %PINXS{api_key: api_key}
+    %PINXS{api_key: api_key, url: "https://api.pin.net.au/1"}
+  end
+
+  def config(api_key, :test) do
+    %PINXS{api_key: api_key, url: "https://test-api.pin.net.au/1"}
+  end
+
+  def config(api_key, url) do
+    %PINXS{api_key: api_key, url: url}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PINXS.MixProject do
   def project do
     [
       app: :pinxs,
-      version: "1.1.0",
+      version: "2.0.0",
       elixir: "~> 1.6",
       source_url: "https://github.com/htdc/pinxs",
       description: """

--- a/test/balance_test.exs
+++ b/test/balance_test.exs
@@ -5,7 +5,7 @@ defmodule PINXS.BalanceTest do
 
   test "Retrieve balance" do
     use_cassette("balance") do
-      {:ok, balance} = Balance.get(PINXS.config("api key"))
+      {:ok, balance} = Balance.get(PINXS.config("api key", :test))
       assert balance.available == [%{amount: 50000, currency: "AUD"}]
     end
   end

--- a/test/bank_accounts/bank_account_test.exs
+++ b/test/bank_accounts/bank_account_test.exs
@@ -13,7 +13,7 @@ defmodule PINXS.BankAccounts.BankAccountTest do
     }
 
     use_cassette("bank_accounts/create") do
-      {:ok, created_account} = BankAccount.create(bank_account, PINXS.config("api_key"))
+      {:ok, created_account} = BankAccount.create(bank_account, PINXS.config("api_key", :test))
 
       assert created_account.number == "XXX456"
       assert created_account.token == "ba_PRNU-gZfs7TAFYQN4fRT9g"

--- a/test/cards/card_test.exs
+++ b/test/cards/card_test.exs
@@ -16,7 +16,7 @@ defmodule PINXS.Cards.CardTest do
     }
 
     use_cassette("cards") do
-      {:ok, response} = Card.create(card, PINXS.config("api_key"))
+      {:ok, response} = Card.create(card, PINXS.config("api_key", :test))
 
       assert response.expiry_year == 2020
     end
@@ -33,7 +33,7 @@ defmodule PINXS.Cards.CardTest do
     }
 
     use_cassette("card_with_missing_field") do
-      {:error, response} = Card.create(card, PINXS.config("api_key"))
+      {:error, response} = Card.create(card, PINXS.config("api_key", :test))
 
       assert response.error_description == "One or more parameters were missing or invalid"
     end

--- a/test/charges/charge_test.exs
+++ b/test/charges/charge_test.exs
@@ -32,7 +32,7 @@ defmodule PINXS.Charges.ChargeTest do
   test "Create a charge with full card details", %{card: card, charge: charge} do
     use_cassette("charge_with_card") do
       charge = %{charge | card: card}
-      {:ok, charge} = Charge.create(charge, PINXS.config("api_key"))
+      {:ok, charge} = Charge.create(charge, PINXS.config("api_key", :test))
       assert charge.amount == 50000
       assert charge.email == "hagrid@hogwarts.wiz"
       assert charge.card.token == "card_R6khtY81EZE5RiqkidVhgA"
@@ -43,7 +43,7 @@ defmodule PINXS.Charges.ChargeTest do
   test "Create an uncaptured charge", %{card: card, charge: charge} do
     use_cassette("charge_uncaptured") do
       charge = %{charge | card: card, capture: false}
-      {:ok, charge} = Charge.create(charge, PINXS.config("api_key"))
+      {:ok, charge} = Charge.create(charge, PINXS.config("api_key", :test))
 
       assert charge.captured == false
     end
@@ -52,7 +52,7 @@ defmodule PINXS.Charges.ChargeTest do
   test "Create a charge with a used token", %{charge: charge, card_token: card_token} do
     use_cassette("charge_with_used_card_token") do
       charge_map = %{charge | card_token: card_token}
-      {:error, err} = Charge.create(charge_map, PINXS.config("api_key"))
+      {:error, err} = Charge.create(charge_map, PINXS.config("api_key", :test))
 
       assert err.error_description ==
                "Token already used. Card tokens can only be used once, to create a charge or assign a card to a customer"
@@ -61,11 +61,11 @@ defmodule PINXS.Charges.ChargeTest do
 
   test "Create a charge with a card token", %{card: card_map, charge: charge} do
     use_cassette("charge_with_card_token") do
-      {:ok, card} = Card.create(card_map, PINXS.config("api_key"))
+      {:ok, card} = Card.create(card_map, PINXS.config("api_key", :test))
 
       charge_map = %{charge | card_token: card.token}
 
-      {:ok, charge} = Charge.create(charge_map, PINXS.config("api_key"))
+      {:ok, charge} = Charge.create(charge_map, PINXS.config("api_key", :test))
 
       assert charge.captured == true
       assert charge.amount == 50000
@@ -74,11 +74,11 @@ defmodule PINXS.Charges.ChargeTest do
 
   test "Create a charge with a customer token", %{charge: charge, customer: customer} do
     use_cassette("charge_with_customer_token") do
-      {:ok, customer} = Customer.create(customer, PINXS.config("api_key"))
+      {:ok, customer} = Customer.create(customer, PINXS.config("api_key", :test))
 
       charge_map = %{charge | customer_token: customer.token}
 
-      {:ok, charge} = Charge.create(charge_map, PINXS.config("api_key"))
+      {:ok, charge} = Charge.create(charge_map, PINXS.config("api_key", :test))
 
       assert charge.captured == true
       assert charge.amount == 50000
@@ -87,11 +87,11 @@ defmodule PINXS.Charges.ChargeTest do
 
   test "Capture a charge", %{charge: charge, card: card} do
     use_cassette("capture_full_charge") do
-      {:ok, uncaptured_charge} = Charge.create(%{charge | capture: false, card: card}, PINXS.config("api_key"))
+      {:ok, uncaptured_charge} = Charge.create(%{charge | capture: false, card: card}, PINXS.config("api_key", :test))
 
       assert uncaptured_charge.captured == false
 
-      {:ok, captured_charge} = Charge.capture(uncaptured_charge, PINXS.config("api_key"))
+      {:ok, captured_charge} = Charge.capture(uncaptured_charge, PINXS.config("api_key", :test))
 
       assert captured_charge.captured == true
     end
@@ -99,11 +99,11 @@ defmodule PINXS.Charges.ChargeTest do
 
   test "Capture a partial charge", %{charge: charge, card: card} do
     use_cassette("capture_partial_charge") do
-      {:ok, uncaptured_charge} = Charge.create(%{charge | capture: false, card: card}, PINXS.config("api_key"))
+      {:ok, uncaptured_charge} = Charge.create(%{charge | capture: false, card: card}, PINXS.config("api_key", :test))
 
       assert uncaptured_charge.captured == false
 
-      {:error, err} = Charge.capture(uncaptured_charge, %{amount: 200}, PINXS.config("api key"))
+      {:error, err} = Charge.capture(uncaptured_charge, %{amount: 200}, PINXS.config("api_key", :test))
 
       assert err.error_description == "You must capture the full amount that was authorised"
     end
@@ -111,7 +111,7 @@ defmodule PINXS.Charges.ChargeTest do
 
   test "Get all charges" do
     use_cassette("get_all_charges") do
-      {:ok, charges} = Charge.get_all(PINXS.config("api key"))
+      {:ok, charges} = Charge.get_all(PINXS.config("api_key", :test))
 
       %{items: [charge | _]} = charges
 
@@ -122,9 +122,9 @@ defmodule PINXS.Charges.ChargeTest do
 
   test "Get a specific charge", %{charge: charge, card: card} do
     use_cassette("get_charge") do
-      {:ok, created_charge} = Charge.create(%{charge | card: card}, PINXS.config("api key"))
+      {:ok, created_charge} = Charge.create(%{charge | card: card}, PINXS.config("api_key", :test))
 
-      {:ok, retreived_charge} = Charge.get(created_charge.token, PINXS.config("api key"))
+      {:ok, retreived_charge} = Charge.get(created_charge.token, PINXS.config("api_key", :test))
 
       assert created_charge == retreived_charge
     end
@@ -132,7 +132,7 @@ defmodule PINXS.Charges.ChargeTest do
 
   test "Search for a charge" do
     use_cassette("search_charges") do
-      {:ok, retreived_charges} = Charge.search(%{query: "hagrid@hogwarts.wiz"}, PINXS.config("api key"))
+      {:ok, retreived_charges} = Charge.search(%{query: "hagrid@hogwarts.wiz"}, PINXS.config("api_key", :test))
 
       assert retreived_charges.count == 25
       assert retreived_charges.items != []
@@ -153,7 +153,7 @@ defmodule PINXS.Charges.ChargeTest do
       failing_card = %{card | number: @card_numbers.declined}
 
       use_cassette("charge_failures/declined") do
-        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api key"))
+        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api_key", :test))
 
         assert declined.error_description == "The card was declined"
       end
@@ -163,7 +163,7 @@ defmodule PINXS.Charges.ChargeTest do
       failing_card = %{card | number: @card_numbers.insufficient_funds}
 
       use_cassette("charge_failures/insufficient_funds") do
-        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api key"))
+        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api_key", :test))
 
         assert declined.error_description == "There are not enough funds available to process the requested amount"
       end
@@ -173,7 +173,7 @@ defmodule PINXS.Charges.ChargeTest do
       failing_card = %{card | number: @card_numbers.invalid_cvc}
 
       use_cassette("charge_failures/invalid_cvc") do
-        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api key"))
+        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api_key", :test))
 
         assert declined.error_description == "The card verification code (cvc) was incorrect"
       end
@@ -183,7 +183,7 @@ defmodule PINXS.Charges.ChargeTest do
       failing_card = %{card | number: @card_numbers.invalid_card}
 
       use_cassette("charge_failures/invalid_card") do
-        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api key"))
+        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api_key", :test))
 
         assert declined.error_description == "The card was invalid"
       end
@@ -193,7 +193,7 @@ defmodule PINXS.Charges.ChargeTest do
       failing_card = %{card | number: @card_numbers.processing_error}
 
       use_cassette("charge_failures/processing_error") do
-        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api key"))
+        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api_key", :test))
 
         assert declined.error_description == "An error occurred while processing the card"
       end
@@ -203,7 +203,7 @@ defmodule PINXS.Charges.ChargeTest do
       failing_card = %{card | number: @card_numbers.suspected_fraud}
 
       use_cassette("charge_failures/suspected_fraud") do
-        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api key"))
+        {:error, declined} = Charge.create(%{charge | card: failing_card}, PINXS.config("api_key", :test))
 
         assert declined.error_description == "The transaction was flagged as possibly fraudulent and subsequently declined"
       end

--- a/test/customers/customer_test.exs
+++ b/test/customers/customer_test.exs
@@ -24,7 +24,7 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Creating a customer", %{customer: customer} do
     use_cassette("create_customer") do
-      {:ok, customer} = Customer.create(customer, PINXS.config("api key"))
+      {:ok, customer} = Customer.create(customer, PINXS.config("api_key", :test))
 
       assert customer.token == "cus_8xtSjuld0NFEzWnUOY0yeA"
     end
@@ -32,7 +32,7 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Create customer with missing information", %{card: card} do
     use_cassette("create_customer_with_missing_fields") do
-      {:error, err} = Customer.create(%Customer{card: card}, PINXS.config("api key"))
+      {:error, err} = Customer.create(%Customer{card: card}, PINXS.config("api_key", :test))
 
       assert err.error_description == "One or more parameters were missing or invalid"
     end
@@ -40,7 +40,7 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Get all customers" do
     use_cassette("get_all_customers") do
-      {:ok, customers} = Customer.get_all(PINXS.config("api key"))
+      {:ok, customers} = Customer.get_all(PINXS.config("api_key", :test))
 
       assert length(customers.items) == 10
     end
@@ -48,7 +48,7 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Get paged customers" do
     use_cassette("get_paged_customers") do
-      {:ok, customers} = Customer.get_all(2, PINXS.config("api key"))
+      {:ok, customers} = Customer.get_all(2, PINXS.config("api_key", :test))
 
       assert customers.items == []
       assert customers.pagination.pages == 1
@@ -57,7 +57,7 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Get single customer" do
     use_cassette("get_customer") do
-      {:ok, customer} = Customer.get("cus_8xtSjuld0NFEzWnUOY0yeA", PINXS.config("api key"))
+      {:ok, customer} = Customer.get("cus_8xtSjuld0NFEzWnUOY0yeA", PINXS.config("api_key", :test))
 
       assert customer.email == "hagrid@hogwarts.wiz"
     end
@@ -65,7 +65,7 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Get a non existing customer" do
     use_cassette("get_non_existing_customer") do
-      {:error, response} = Customer.get("whatevs", PINXS.config("api key"))
+      {:error, response} = Customer.get("whatevs", PINXS.config("api_key", :test))
 
       assert response.error == "not_found"
     end
@@ -73,9 +73,9 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Update a customer" do
     use_cassette("update_customer") do
-      {:ok, customer} = Customer.get("cus_8xtSjuld0NFEzWnUOY0yeA", PINXS.config("api key"))
+      {:ok, customer} = Customer.get("cus_8xtSjuld0NFEzWnUOY0yeA", PINXS.config("api_key", :test))
       to_update = %{email: "hagrid@gmail.com"}
-      {:ok, updated} = Customer.update(customer, to_update, PINXS.config("api key"))
+      {:ok, updated} = Customer.update(customer, to_update, PINXS.config("api_key", :test))
 
       assert updated.email == "hagrid@gmail.com"
     end
@@ -83,9 +83,9 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Delete a customer", %{customer: customer} do
     use_cassette("delete_customer") do
-      {:ok, created_customer} = Customer.create(customer, PINXS.config("api key"))
+      {:ok, created_customer} = Customer.create(customer, PINXS.config("api_key", :test))
 
-      {:ok, deleted} = Customer.delete(created_customer, PINXS.config("api key"))
+      {:ok, deleted} = Customer.delete(created_customer, PINXS.config("api_key", :test))
 
       assert deleted == true
     end
@@ -93,7 +93,7 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Get customer's charges", %{customer: customer} do
     use_cassette("get_customer_charges") do
-      {:ok, created_customer} = Customer.create(customer, PINXS.config("api key"))
+      {:ok, created_customer} = Customer.create(customer, PINXS.config("api_key", :test))
 
       charge = %Charge{
         email: "hagrid@hogwarts.wiz",
@@ -103,9 +103,9 @@ defmodule PINXS.Customers.CustomerTest do
         customer_token: created_customer.token
       }
 
-      {:ok, _} = Charge.create(charge, PINXS.config("api key"))
+      {:ok, _} = Charge.create(charge, PINXS.config("api_key", :test))
 
-      {:ok, %{items: [charge | _]}} = Customer.get_charges(created_customer, PINXS.config("api key"))
+      {:ok, %{items: [charge | _]}} = Customer.get_charges(created_customer, PINXS.config("api_key", :test))
 
       assert charge.description == "Dragon eggs"
     end
@@ -113,8 +113,8 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Get customer's cards", %{customer: customer} do
     use_cassette("get_customer_cards") do
-      {:ok, created_customer} = Customer.create(customer, PINXS.config("api key"))
-      {:ok, %{items: [card | _]}} = Customer.get_cards(created_customer, PINXS.config("api key"))
+      {:ok, created_customer} = Customer.create(customer, PINXS.config("api_key", :test))
+      {:ok, %{items: [card | _]}} = Customer.get_cards(created_customer, PINXS.config("api_key", :test))
 
       assert card.expiry_year == 2020
     end
@@ -122,9 +122,9 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Add card to customer", %{customer: customer, card: card} do
     use_cassette("add_card_to_customer") do
-      {:ok, created_customer} = Customer.create(customer, PINXS.config("api key"))
+      {:ok, created_customer} = Customer.create(customer, PINXS.config("api_key", :test))
 
-      {:ok, created_card} = Customer.add_card(created_customer, %{card | expiry_year: 2019}, PINXS.config("api key"))
+      {:ok, created_card} = Customer.add_card(created_customer, %{card | expiry_year: 2019}, PINXS.config("api_key", :test))
 
       assert created_card.expiry_year == 2019
     end
@@ -132,10 +132,10 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Add card to customer with token", %{customer: customer, card: card} do
     use_cassette("add_card_token_to_customer") do
-      {:ok, created_customer} = Customer.create(customer, PINXS.config("api key"))
-      {:ok, created_card} = Card.create(%{card | expiry_year: 2018}, PINXS.config("api key"))
+      {:ok, created_customer} = Customer.create(customer, PINXS.config("api_key", :test))
+      {:ok, created_card} = Card.create(%{card | expiry_year: 2018}, PINXS.config("api_key", :test))
 
-      {:ok, added_card} = Customer.add_card(created_customer, created_card.token, PINXS.config("api key"))
+      {:ok, added_card} = Customer.add_card(created_customer, created_card.token, PINXS.config("api_key", :test))
 
       assert added_card.expiry_year == 2018
     end
@@ -143,10 +143,10 @@ defmodule PINXS.Customers.CustomerTest do
 
   test "Delete customer card", %{customer: customer, card: card} do
     use_cassette("delete_customer_card") do
-      {:ok, created_customer} = Customer.create(customer, PINXS.config("api key"))
-      {:ok, created_card} = Customer.add_card(created_customer, %{card | expiry_year: 2019}, PINXS.config("api key"))
+      {:ok, created_customer} = Customer.create(customer, PINXS.config("api_key", :test))
+      {:ok, created_card} = Customer.add_card(created_customer, %{card | expiry_year: 2019}, PINXS.config("api_key", :test))
 
-      {:ok, delete_card} = Customer.delete_card(created_customer, created_card.token, PINXS.config("api key"))
+      {:ok, delete_card} = Customer.delete_card(created_customer, created_card.token, PINXS.config("api_key", :test))
 
       assert delete_card == true
     end

--- a/test/pinxs_test.exs
+++ b/test/pinxs_test.exs
@@ -1,0 +1,4 @@
+defmodule PINXSTest do
+  use ExUnit.Case, async: true
+  doctest(PINXS)
+end

--- a/test/recipient/recipient_test.exs
+++ b/test/recipient/recipient_test.exs
@@ -21,7 +21,7 @@ defmodule PINXS.Recipient.RecipientTest do
 
   test "Create a recipient", %{recipient: recipient, bank_account: bank_account} do
     use_cassette("recipients/create") do
-      {:ok, created} = Recipient.create(%{ recipient | bank_account: bank_account}, PINXS.config("api key"))
+      {:ok, created} = Recipient.create(%{ recipient | bank_account: bank_account}, PINXS.config("api_key", :test))
 
       assert created.token != nil
     end
@@ -29,9 +29,9 @@ defmodule PINXS.Recipient.RecipientTest do
 
   test "Create recipient from bank account token", %{recipient: recipient, bank_account: bank_account} do
     use_cassette("recipients/create_from_token") do
-      {:ok, created_account} = BankAccount.create(bank_account, PINXS.config("api key"))
+      {:ok, created_account} = BankAccount.create(bank_account, PINXS.config("api_key", :test))
 
-      {:ok, created} = Recipient.create(%{ recipient | bank_account_token: created_account.token}, PINXS.config("api key"))
+      {:ok, created} = Recipient.create(%{ recipient | bank_account_token: created_account.token}, PINXS.config("api_key", :test))
 
       assert created.token != nil
     end
@@ -39,9 +39,9 @@ defmodule PINXS.Recipient.RecipientTest do
 
   test "Get a recipient", %{recipient: recipient, bank_account: bank_account} do
     use_cassette("recipients/get") do
-      {:ok, created} = Recipient.create(%{ recipient | bank_account: bank_account}, PINXS.config("api key"))
+      {:ok, created} = Recipient.create(%{ recipient | bank_account: bank_account}, PINXS.config("api_key", :test))
 
-      {:ok, retrieved} = Recipient.get(created.token, PINXS.config("api key"))
+      {:ok, retrieved} = Recipient.get(created.token, PINXS.config("api_key", :test))
 
       assert created == retrieved
     end
@@ -49,18 +49,18 @@ defmodule PINXS.Recipient.RecipientTest do
 
   test "Get all" do
     use_cassette("recipients/get_all") do
-      {:ok, %{items: [recipient | _]}} = Recipient.get_all(PINXS.config("api key"))
+      {:ok, %{items: [recipient | _]}} = Recipient.get_all(PINXS.config("api_key", :test))
 
       assert recipient.token =~ ~r/rp_.*/
     end
   end
   test "Update recipient with new bank account", %{recipient: recipient, bank_account: bank_account} do
     use_cassette("recipients/update") do
-      {:ok, created} = Recipient.create(%{ recipient | bank_account: bank_account}, PINXS.config("api key"))
+      {:ok, created} = Recipient.create(%{ recipient | bank_account: bank_account}, PINXS.config("api_key", :test))
 
-      {:ok, created_account} = BankAccount.create(bank_account, PINXS.config("api key"))
+      {:ok, created_account} = BankAccount.create(bank_account, PINXS.config("api_key", :test))
 
-      {:ok, updated_recipient} = Recipient.update_recipient(created, %{bank_account_token: created_account.token}, PINXS.config("api key"))
+      {:ok, updated_recipient} = Recipient.update_recipient(created, %{bank_account_token: created_account.token}, PINXS.config("api_key", :test))
 
       assert created.bank_account != updated_recipient.bank_account
     end

--- a/test/refunds/refund_test.exs
+++ b/test/refunds/refund_test.exs
@@ -28,9 +28,9 @@ defmodule PINXS.Refunds.RefundTest do
 
   test "Create a refund", %{charge: charge, card: card} do
     use_cassette("refunds/create") do
-      {:ok, created_charge} = Charge.create(%{charge | card: card}, PINXS.config("api key"))
+      {:ok, created_charge} = Charge.create(%{charge | card: card}, PINXS.config("api_key", :test))
 
-      {:ok, refund} = Refund.create(created_charge, PINXS.config("api key"))
+      {:ok, refund} = Refund.create(created_charge, PINXS.config("api_key", :test))
 
       assert refund.amount == 50000
       assert refund.token != nil
@@ -39,7 +39,7 @@ defmodule PINXS.Refunds.RefundTest do
 
   test "Get all refunds" do
     use_cassette("refunds/get_all") do
-      {:ok, refunds} = Refund.get_all(PINXS.config("api key"))
+      {:ok, refunds} = Refund.get_all(PINXS.config("api_key", :test))
 
       assert length(refunds.items) == 10
     end
@@ -47,11 +47,11 @@ defmodule PINXS.Refunds.RefundTest do
 
   test "Get a refund", %{charge: charge, card: card} do
     use_cassette("refunds/get_one") do
-      {:ok, created_charge} = Charge.create(%{charge | card: card}, PINXS.config("api key"))
+      {:ok, created_charge} = Charge.create(%{charge | card: card}, PINXS.config("api_key", :test))
 
-      {:ok, refund} = Refund.create(created_charge, PINXS.config("api key"))
+      {:ok, refund} = Refund.create(created_charge, PINXS.config("api_key", :test))
 
-      {:ok, retrieved_refund} = Refund.get(refund, PINXS.config("api key"))
+      {:ok, retrieved_refund} = Refund.get(refund, PINXS.config("api_key", :test))
 
       assert refund == retrieved_refund
     end
@@ -59,11 +59,11 @@ defmodule PINXS.Refunds.RefundTest do
 
   test "Get refunds for a charge", %{charge: charge, card: card} do
     use_cassette("refunds/get_refunds_for_charge") do
-      {:ok, created_charge} = Charge.create(%{charge | card: card}, PINXS.config("api key"))
+      {:ok, created_charge} = Charge.create(%{charge | card: card}, PINXS.config("api_key", :test))
 
-      {:ok, refund} = Refund.create(created_charge, PINXS.config("api key"))
+      {:ok, refund} = Refund.create(created_charge, PINXS.config("api_key", :test))
 
-      {:ok, retrieved_refunds} = Refund.get_all_for_charge(created_charge, PINXS.config("api key"))
+      {:ok, retrieved_refunds} = Refund.get_all_for_charge(created_charge, PINXS.config("api_key", :test))
 
       assert [refund] == retrieved_refunds.items
     end

--- a/test/transfers/transfer_test.exs
+++ b/test/transfers/transfer_test.exs
@@ -28,9 +28,9 @@ defmodule PINXS.Transfers.TransferTest do
 
   test "Create a transfer", %{transfer: transfer, recipient: recipient} do
     use_cassette("transfers/create") do
-      {:ok, created_recipient} = Recipient.create(recipient, PINXS.config("api key"))
+      {:ok, created_recipient} = Recipient.create(recipient, PINXS.config("api_key", :test))
 
-      {:ok, created_transfer} = Transfer.create(%{transfer | currency: "AUD",  recipient: created_recipient.token}, PINXS.config("api key"))
+      {:ok, created_transfer} = Transfer.create(%{transfer | currency: "AUD",  recipient: created_recipient.token}, PINXS.config("api_key", :test))
 
       assert created_transfer.token != nil
     end
@@ -38,9 +38,9 @@ defmodule PINXS.Transfers.TransferTest do
 
   test "Create a transfer with missing currency", %{transfer: transfer, recipient: recipient} do
     use_cassette("transfers/create_with_missing_currency") do
-      {:ok, created_recipient} = Recipient.create(recipient, PINXS.config("api key"))
+      {:ok, created_recipient} = Recipient.create(recipient, PINXS.config("api_key", :test))
 
-      {:ok, created_transfer} = Transfer.create(%{transfer | recipient: created_recipient.token}, PINXS.config("api key"))
+      {:ok, created_transfer} = Transfer.create(%{transfer | recipient: created_recipient.token}, PINXS.config("api_key", :test))
 
       assert created_transfer.token != nil
     end
@@ -48,7 +48,7 @@ defmodule PINXS.Transfers.TransferTest do
 
   test "Get all transfers" do
     use_cassette("transfers/get_all") do
-      {:ok, %{items: [transfer | _]}} = Transfer.get_all(PINXS.config("api key"))
+      {:ok, %{items: [transfer | _]}} = Transfer.get_all(PINXS.config("api_key", :test))
 
       assert transfer != nil
     end
@@ -56,7 +56,7 @@ defmodule PINXS.Transfers.TransferTest do
 
   test "Get specific page of transfers" do
     use_cassette("transfers/get_all_by_page") do
-      {:ok, %{items: items}} = Transfer.get_all(2, PINXS.config("api key"))
+      {:ok, %{items: items}} = Transfer.get_all(2, PINXS.config("api_key", :test))
 
       assert items == []
     end
@@ -64,11 +64,11 @@ defmodule PINXS.Transfers.TransferTest do
 
   test "Get a transfer", %{transfer: transfer, recipient: recipient} do
     use_cassette("transfers/get_specific_transfer") do
-      {:ok, created_recipient} = Recipient.create(recipient, PINXS.config("api key"))
+      {:ok, created_recipient} = Recipient.create(recipient, PINXS.config("api_key", :test))
 
-      {:ok, created_transfer} = Transfer.create(%{transfer | currency: "AUD",  recipient: created_recipient.token}, PINXS.config("api key"))
+      {:ok, created_transfer} = Transfer.create(%{transfer | currency: "AUD",  recipient: created_recipient.token}, PINXS.config("api_key", :test))
 
-      {:ok, retrieved_transfer} = Transfer.get(created_transfer.token, PINXS.config("api key"))
+      {:ok, retrieved_transfer} = Transfer.get(created_transfer.token, PINXS.config("api_key", :test))
 
       assert created_transfer == retrieved_transfer
     end
@@ -76,7 +76,7 @@ defmodule PINXS.Transfers.TransferTest do
 
   test "Search for a transfer" do
     use_cassette("transfers/search") do
-      {:ok, retrieved_transfers} = Transfer.search(%{query: "hagrid@hogwarts.wiz"}, PINXS.config("api key"))
+      {:ok, retrieved_transfers} = Transfer.search(%{query: "hagrid@hogwarts.wiz"}, PINXS.config("api_key", :test))
 
       assert retrieved_transfers.count == 5
       assert retrieved_transfers.items != []
@@ -85,11 +85,11 @@ defmodule PINXS.Transfers.TransferTest do
 
   test "Get line items", %{transfer: transfer, recipient: recipient} do
     use_cassette("transfers/get_line_items") do
-      {:ok, created_recipient} = Recipient.create(recipient, PINXS.config("api key"))
+      {:ok, created_recipient} = Recipient.create(recipient, PINXS.config("api_key", :test))
 
-      {:ok, created_transfer} = Transfer.create(%{transfer | currency: "AUD",  recipient: created_recipient.token}, PINXS.config("api key"))
+      {:ok, created_transfer} = Transfer.create(%{transfer | currency: "AUD",  recipient: created_recipient.token}, PINXS.config("api_key", :test))
 
-      {:ok, %{items: items}} = Transfer.get_line_items(created_transfer.token, PINXS.config("api key"))
+      {:ok, %{items: items}} = Transfer.get_line_items(created_transfer.token, PINXS.config("api_key", :test))
 
       assert items != []
     end

--- a/test/webhooks/webhooks_test.exs
+++ b/test/webhooks/webhooks_test.exs
@@ -5,7 +5,7 @@ defmodule PINXS.Webhooks.WebhookTest do
 
   test "Creates a webhook" do
     use_cassette("webhooks/create") do
-      {:ok, webhook} = Webhook.create(%Webhook{url: "https://www.example.com/webhooks"}, PINXS.config("api_key"))
+      {:ok, webhook} = Webhook.create(%Webhook{url: "https://www.example.com/webhooks"}, PINXS.config("api_key", :test))
 
       assert webhook.token != nil
     end
@@ -13,9 +13,9 @@ defmodule PINXS.Webhooks.WebhookTest do
 
   test "Retrieve webooks" do
     use_cassette("webhooks/get_all") do
-      {:ok, webhook} = Webhook.create(%Webhook{url: "https://www.example.com/webhooks"}, PINXS.config("api_key"))
+      {:ok, webhook} = Webhook.create(%Webhook{url: "https://www.example.com/webhooks"}, PINXS.config("api_key", :test))
 
-      {:ok, [retreived_hook]} = Webhook.get(PINXS.config("api_key"))
+      {:ok, [retreived_hook]} = Webhook.get(PINXS.config("api_key", :test))
 
       assert webhook == retreived_hook
     end
@@ -23,9 +23,9 @@ defmodule PINXS.Webhooks.WebhookTest do
 
   test "Retrieve specific webhook" do
     use_cassette("webhooks/get") do
-      {:ok, webhook} = Webhook.create(%Webhook{url: "https://www.example.com/webhooks"}, PINXS.config("api_key"))
+      {:ok, webhook} = Webhook.create(%Webhook{url: "https://www.example.com/webhooks"}, PINXS.config("api_key", :test))
 
-      {:ok, retreived_hook} = Webhook.get(webhook.token, PINXS.config("api_key"))
+      {:ok, retreived_hook} = Webhook.get(webhook.token, PINXS.config("api_key", :test))
 
       assert webhook == retreived_hook
     end
@@ -33,9 +33,9 @@ defmodule PINXS.Webhooks.WebhookTest do
 
   test "Delete webhook" do
     use_cassette("webhooks/delete") do
-      {:ok, webhook} = Webhook.create(%Webhook{url: "https://www.example.com/webhooks"}, PINXS.config("So20sGs16NskDJmmAG36xA"))
+      {:ok, webhook} = Webhook.create(%Webhook{url: "https://www.example.com/webhooks"}, PINXS.config("api_key", :test))
 
-      {:ok, result} = Webhook.delete(webhook.token, PINXS.config("api_key"))
+      {:ok, result} = Webhook.delete(webhook.token, PINXS.config("api_key", :test))
 
       assert result
     end


### PR DESCRIPTION
Allow runtime configuration of the URL to hit.

*BREAKING CHANGE* URL is set per request now, rather than being taking from your application config.  For most users this will not be a problem, the default is the production URL.  This means you may need to make changes in test environments, however.  Switch to the new `PINXS.config(api_key, :test)` invocation