### PR TITLE
Adds a new struct for transfer line items

### DIFF
--- a/lib/transfers/line_item.ex
+++ b/lib/transfers/line_item.ex
@@ -1,0 +1,22 @@
+defmodule PINXS.Transfers.LineItem do
+  @derive [Jason.Encoder]
+  defstruct [
+    :type,
+    :amount,
+    :currency,
+    :created_at,
+    :object,
+    :token,
+    :record
+  ]
+
+  @type t :: %__MODULE__{
+          type: nil | String.t(),
+          amount: integer(),
+          currency: nil | String.t(),
+          created_at: nil | String.t(),
+          object: nil | String.t(),
+          token: nil | String.t(),
+          record: map()
+        }
+end

--- a/lib/transfers/transfer.ex
+++ b/lib/transfers/transfer.ex
@@ -71,11 +71,11 @@ defmodule PINXS.Transfers.Transfer do
   end
 
   def get_line_items(transfer_token, config) do
-    API.get("/transfers/#{transfer_token}/line_items?per_page=500", __MODULE__, config)
+    API.get("/transfers/#{transfer_token}/line_items?per_page=500", PINXS.Transfers.LineItem, config)
   end
 
   def get_line_items(transfer_token, page, config) do
-    API.get("/transfers/#{transfer_token}/line_items?page=#{page}&per_page=500", __MODULE__, config)
+    API.get("/transfers/#{transfer_token}/line_items?page=#{page}&per_page=500", PINXS.Transfers.LineItem, config)
   end
 
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PINXS.MixProject do
   def project do
     [
       app: :pinxs,
-      version: "3.3.0",
+      version: "3.4.0",
       elixir: "~> 1.6",
       source_url: "https://github.com/htdc/pinxs",
       description: """


### PR DESCRIPTION
`PINXS.Transfers.Transfer.get_line_items` currently returns line items _as_ `PINXS.Transfers.Transfer` structs, because of what's going on [here](https://github.com/htdc/pinxs/blob/master/lib/http/response.ex#L23). This change passes through a new module that defines a separate struct for `Transfers.LineItem`.